### PR TITLE
fix(redirect_uri): fix bad_redirect_uri error

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,9 @@ const microAuthSlack = ({ clientId, clientSecret, callbackUrl, path = '/auth/sla
             client_id: clientId,
             // eslint-disable-next-line camelcase
             client_secret: clientSecret,
-            code
+            code,
+            // eslint-disable-next-line camelcase
+            redirect_uri: callbackUrl
           },
           json: true
         });


### PR DESCRIPTION
When providing a `callbackUrl`, it is send as `redirect_uri` parameter in the first request. But the second request to get the token needs the same `redirect_uri` or it throfs `bad_redirect_uri` error. This PR fixes it.